### PR TITLE
chore(node-transcription): upgrade to @deepgram/sdk v5 API

### DIFF
--- a/deepgram.toml
+++ b/deepgram.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/deepgram-starters/node-transcription"
 useCase = "transcription"
 language = "javascript"
 framework = "node"
-sdk = "4.11.3"
+sdk = "@deepgram/sdk"
 tags = ["transcription", "stt", "speech-to-text", "asr", "pre-recorded", "javascript", "node"]
 
 # Check prerequisites (run via `make check-prereqs`)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/deepgram-starters/node-transcription#readme",
   "dependencies": {
-    "@deepgram/sdk": "4.11.3",
+    "@deepgram/sdk": "^5.7.0",
     "cors": "2.8.5",
     "dotenv": "17.2.3",
     "express": "5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@deepgram/sdk':
-        specifier: 4.11.3
-        version: 4.11.3
+        specifier: ^5.7.0
+        version: 5.7.0
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -36,16 +36,9 @@ importers:
 
 packages:
 
-  '@deepgram/captions@1.2.0':
-    resolution: {integrity: sha512-8B1C/oTxTxyHlSFubAhNRgCbQ2SQ5wwvtlByn8sDYZvdDtdn/VE2yEPZ4BvUnrKWmsbTQY6/ooLV+9Ka2qmDSQ==}
+  '@deepgram/sdk@5.7.0':
+    resolution: {integrity: sha512-A0uIaLukO+8JXUuT+iDE5ts8PCmdLCxDajawghFHLDEnFvA8dYYecCFxqFaTWgjJcJil0CtgIHKzm23E4RVqOA==}
     engines: {node: '>=18.0.0'}
-
-  '@deepgram/sdk@4.11.3':
-    resolution: {integrity: sha512-7NujHlAX6ciBeYAkxkhE7LCZWy0JK3nvFsV2VwVZIUiFR40ykhep5fxYd7ZovM+PbNyCoM8GKNMHu9MeQ5/wTQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -129,12 +122,6 @@ packages:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
 
-  cross-fetch@3.2.0:
-    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
-
-  dayjs@1.11.19:
-    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -143,10 +130,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -188,10 +171,6 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-
-  events@3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -370,15 +349,6 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   nodemon@3.1.10:
     resolution: {integrity: sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==}
     engines: {node: '>=10'}
@@ -517,9 +487,6 @@ packages:
     resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
     hasBin: true
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -534,9 +501,6 @@ packages:
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -548,17 +512,11 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -575,26 +533,12 @@ packages:
 
 snapshots:
 
-  '@deepgram/captions@1.2.0':
+  '@deepgram/sdk@5.7.0':
     dependencies:
-      dayjs: 1.11.19
-
-  '@deepgram/sdk@4.11.3':
-    dependencies:
-      '@deepgram/captions': 1.2.0
-      '@types/node': 18.19.130
-      cross-fetch: 3.2.0
-      deepmerge: 4.3.1
-      events: 3.3.0
-      ws: 8.18.3
+      ws: 8.21.1
     transitivePeerDependencies:
       - bufferutil
-      - encoding
       - utf-8-validate
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
 
   accepts@2.0.0:
     dependencies:
@@ -689,21 +633,11 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cross-fetch@3.2.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
-  dayjs@1.11.19: {}
-
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
-
-  deepmerge@4.3.1: {}
 
   depd@2.0.0: {}
 
@@ -734,8 +668,6 @@ snapshots:
   escape-html@1.0.3: {}
 
   etag@1.8.1: {}
-
-  events@3.3.0: {}
 
   express@5.2.1:
     dependencies:
@@ -940,10 +872,6 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   nodemon@3.1.10:
     dependencies:
       chokidar: 3.6.0
@@ -1104,8 +1032,6 @@ snapshots:
 
   touch@3.1.1: {}
 
-  tr46@0.0.3: {}
-
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -1121,23 +1047,14 @@ snapshots:
 
   undefsafe@2.0.5: {}
 
-  undici-types@5.26.5: {}
-
   unpipe@1.0.0: {}
 
   util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
 
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
   wrappy@1.0.2: {}
 
-  ws@8.18.3: {}
+  ws@8.21.1: {}
 
   xtend@4.0.2: {}

--- a/server.js
+++ b/server.js
@@ -189,11 +189,13 @@ async function transcribeAudio(dgRequest, model = DEFAULT_MODEL) {
     });
   }
 
-  // File transcription
-  return await deepgram.listen.v1.media.transcribeFile(dgRequest.buffer, {
-    model,
-    mimetype: dgRequest.mimetype,
-  });
+  // File transcription. The uploaded file's MIME type must travel on the
+  // uploadable (Content-Type header) — the request-options object has no
+  // `mimetype` field in v5, so passing it there would be silently dropped.
+  return await deepgram.listen.v1.media.transcribeFile(
+    { data: dgRequest.buffer, contentType: dgRequest.mimetype },
+    { model }
+  );
 }
 
 /**

--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@
 
 require("dotenv").config();
 
-const { createClient } = require("@deepgram/sdk");
+const { DeepgramClient } = require("@deepgram/sdk");
 const cors = require("cors");
 const crypto = require("crypto");
 const express = require("express");
@@ -137,7 +137,7 @@ const apiKey = loadApiKey();
 // ============================================================================
 
 // Initialize Deepgram client
-const deepgram = createClient(apiKey);
+const deepgram = new DeepgramClient({ apiKey });
 
 // Configure Multer for file uploads (stores files in memory)
 const storage = multer.memoryStorage();
@@ -183,14 +183,14 @@ function validateTranscriptionInput(file, url) {
 async function transcribeAudio(dgRequest, model = DEFAULT_MODEL) {
   // URL transcription
   if (dgRequest.url) {
-    return await deepgram.listen.prerecorded.transcribeUrl(
-      { url: dgRequest.url },
-      { model }
-    );
+    return await deepgram.listen.v1.media.transcribeUrl({
+      url: dgRequest.url,
+      model,
+    });
   }
 
   // File transcription
-  return await deepgram.listen.prerecorded.transcribeFile(dgRequest.buffer, {
+  return await deepgram.listen.v1.media.transcribeFile(dgRequest.buffer, {
     model,
     mimetype: dgRequest.mimetype,
   });
@@ -205,7 +205,8 @@ async function transcribeAudio(dgRequest, model = DEFAULT_MODEL) {
  * @returns {Object} - Formatted response object
  */
 function formatTranscriptionResponse(transcriptionResponse, modelName) {
-  const transcription = transcriptionResponse.result;
+  // v5 returns the transcription data directly (v4 wrapped it in `.result`).
+  const transcription = transcriptionResponse;
   const result = transcription?.results?.channels?.[0]?.alternatives?.[0];
 
   if (!result) {


### PR DESCRIPTION
## What

Upgrades `node-transcription` from `@deepgram/sdk` v4 to `^5.7.0` and migrates the backend to the v5 API surface. Part of the Deepgram starters SDK-migration / version-standardization rollout.

## How

Surgical changes to the Deepgram-facing calls in `server.js` only — routes, JWT session auth, multer upload, `/api/session`, `/api/metadata`, and the response shape returned to the frontend are unchanged, so the paired `transcription-html` frontend needs no edits.

- **Client init:** `createClient(apiKey)` → `new DeepgramClient({ apiKey })`
- **URL transcription:** `deepgram.listen.prerecorded.transcribeUrl({ url }, { model })` → `deepgram.listen.v1.media.transcribeUrl({ url, model })`
- **File transcription:** `deepgram.listen.prerecorded.transcribeFile(buffer, opts)` → `deepgram.listen.v1.media.transcribeFile(buffer, opts)`
- **Result handling:** v5 returns the transcription data directly and throws on error (v4 returned a `{ result, error }` tuple). `formatTranscriptionResponse()` now reads the response object directly; the existing route-level `try/catch` handles thrown errors.
- **`deepgram.toml`:** `sdk = "4.11.3"` → `sdk = "@deepgram/sdk"` (matches the gold reference pattern; this value is surfaced to clients via `/api/metadata`).
- `package.json`: `@deepgram/sdk` `4.11.3` → `^5.7.0`; lockfile updated via `corepack pnpm install`.

## Verified

- `node --check server.js` passes.
- Boot test: `DEEPGRAM_API_KEY=dummy PORT=8094 node server.js` starts cleanly; `GET /api/metadata` returns the expected JSON (now with `"sdk":"@deepgram/sdk"`) and `GET /api/session` returns a token.
- Not run live (no real transcription performed).

## Manual verification needed before merge

- [ ] Run a real transcription (file upload **and** URL) with a real `DEEPGRAM_API_KEY` and confirm the frontend renders the transcript, words, and metadata correctly.
- [ ] Confirm the paired `transcription-html` frontend works unchanged.